### PR TITLE
Database structure allowing different databases to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,5 @@ data/
 # etc etc
 .idea
 package-lock.json
+config.js*
 db

--- a/STORAGE_IMPLEMENTATION.md
+++ b/STORAGE_IMPLEMENTATION.md
@@ -6,7 +6,7 @@ You can find the base file for the Store in `src/base/HarunaStore.js`.  Create a
 * `async put(id, value)`
 * `async get(id)`
 * `_clean(callback)`
-> I do advise you to grab the latest file from the repo and put it in your repo/project/etc. It'll be much easier.
+> I advise you to grab the latest file from the repo and put it in your repo/project/etc. It'll be much easier.
 
 ### `get name()`
 This is a getter that defines the name of the store. This value should be changed.

--- a/STORAGE_IMPLEMENTATION.md
+++ b/STORAGE_IMPLEMENTATION.md
@@ -1,0 +1,47 @@
+# How to implement your own Data Store
+
+You can find the base file for the Store in `src/base/HarunaStore.js`.  Create a class that extends that and make sure it includes:
+* `get name()`
+* `async init()`
+* `async put(id, value)`
+* `async get(id)`
+* `_clean(callback)`
+> I do advise you to grab the latest file from the repo and put it in your repo/project/etc. It'll be much easier.
+
+### `get name()`
+This is a getter that defines the name of the store. This value should be changed.
+
+### `async init()`
+This is the method that will be called when the store attempts to initialize the database.
+
+### `async put(id, value)`
+This method will be called if Haruna wants to put something into the database. ID should be a `string` and value depends. You should check `src/Haruna.js` `_onVote()` method for details regarding the data saved. This may change.
+
+### `async get(id)`
+This method will be called when Haruna wants to get something. Should return the value stored.
+
+### `_clean(callback)`
+This method is called when the cron job starts. It is responsible for cleaning the database. Please implement your own TTL check logic here. You may use `src/LevelStore.js` as a reference.
+The `callback` is a function with an argument which is supposed to be number of entries removed.
+Example:
+```js
+_clean(callback) {
+    const sweepTime = Date.now()
+    let counter = 0
+    for (const [key, val] of this.db) {
+        if (val.time === sweepTime) {
+            this.db.delete(key)
+            counter ++
+        }
+    }
+    callback(counter)
+}
+```
+
+If you didn't implement any of the core methods, a warning message will show up when you boot Haruna up. In that case, just turn it off and implement what you missed.
+
+
+#### Extra note
+* If you want to change the database error messages, you can extend `_error(err)` method. It doesn't really affect much, besides the default handler is nice already *owo*
+
+* Unfortunately, graceful shutdown hook is not available yet; just hook something to `process.once('beforeExit')` or `process.once('exit')` so you can gracefully shut down the connection.

--- a/src/LevelStore.js
+++ b/src/LevelStore.js
@@ -1,18 +1,19 @@
 const fs = require('fs')
+const { join } = require('path')
 const level = require('level')
 
-class HarunaStore {
-    constructor(Haruna) {
-        console.log('[Notice] Initializing Haruna\'s Database')
-        Object.defineProperty(this, 'haruna', { value: Haruna })
-        Object.defineProperty(this, 'location', { value: process.cwd() })
-        if (!fs.existsSync(this.location + '/db')) fs.mkdirSync(this.location + '/db')
-        if (!fs.existsSync(this.location + '/db/haruna')) fs.mkdirSync(this.location + '/db/haruna')
-        Object.defineProperty(this, 'db', { value: level(this.location + '/db/haruna', { valueEncoding: 'json' }) })
-        console.log('[Notice] Haruna\'s Database Initialized')
+const HarunaStore = require('./base/HarunaStore.js')
+
+class LevelStore extends HarunaStore {
+    get name() { return 'Level Store' }
+
+    async init() {
+        if (!fs.existsSync(join(this.location, 'db'))) fs.mkdirSync(join(this.location, 'db'))
+        if (!fs.existsSync(join(this.location, 'db', 'haruna'))) fs.mkdirSync(join(this.location, 'db', 'haruna'))
+        Object.defineProperty(this, 'db', { value: level(join(this.location, 'db', 'haruna'), { valueEncoding: 'json' }) })
     }
 
-    put(id, value) {
+    async put(id, value) {
         return this.db.put(id, value)
     }
 
@@ -53,19 +54,5 @@ class HarunaStore {
                 }
             })
     }
-
-    _errored(error) {
-        console.error(error)
-        this.haruna.execWebhook({
-            embeds: [{
-                color: 0x9B767B,
-                description: `⚠ Error in executing the Batch Clean ${error.toString()}`,
-                timestamp: new Date(),
-                footer: {
-                    text: 'Haruna Store'
-                }
-            }]
-        }).catch(console.error)
-    }
 }
-module.exports = HarunaStore
+module.exports = LevelStore

--- a/src/base/HarunaStore.js
+++ b/src/base/HarunaStore.js
@@ -1,0 +1,43 @@
+class HarunaStore {
+    constructor(Haruna) {
+        console.log('[Notice] Initializing Haruna\'s Database')
+        Object.defineProperty(this, 'haruna', { value: Haruna })
+        Object.defineProperty(this, 'location', { value: process.cwd() })
+        this.init()
+            .then(() => console.log('[Notice] Haruna\'s Database Initialized'))
+    }
+
+    get name() { return 'Base Store' }
+
+    async init() {
+        console.log('[Warning] If you see this message, that means the data store is not properly implemented. Please contact the author.')
+    }
+
+    async put(id, value) {
+        console.log('[Warning] If you see this message, that means the data store is not properly implemented. Please contact the author.')
+    }
+
+    async get(id) {
+        console.log('[Warning] If you see this message, that means the data store is not properly implemented. Please contact the author.')
+    }
+
+    _clean(callback) {
+        console.log('[Warning] If you see this message, that means the data store is not properly implemented. Please contact the author.')
+    }
+
+    _errored(error) {
+        console.error(error)
+        this.haruna.execWebhook({
+            embeds: [{
+                color: 0x9B767B,
+                description: `⚠ Error in executing the Batch Clean ${error}`,
+                timestamp: new Date(),
+                footer: {
+                    text: this.name
+                }
+            }]
+        })
+            .catch(console.error)
+    }
+}
+module.exports = HarunaStore

--- a/src/base/HarunaStore.js
+++ b/src/base/HarunaStore.js
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright (c) 2019 Deivu (Saya) and takase1121 (Takase)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
 class HarunaStore {
     constructor(Haruna) {
         console.log('[Notice] Initializing Haruna\'s Database')


### PR DESCRIPTION
Converted `HarunaStore.js` into a common interface. Users might be able to just install a module to use alternative databases like SQLite, MySQL, Mongo, Postgres, etc.
 This may allow them to integrate them within their application easier (use the same database as their app uses.)
Not only that, by using a non-level backed store, Haruna may be able to run in clusters / allowing other people to access the DB